### PR TITLE
include http-server for running examples locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@ The main branch is gh-pages, so all of the examples in `code/` should
 run at http://rpflorence.github.io/react-training/code (but you'll have
 to punch in the URL for now).
 
+
+## Running the examples locally
+
+```bash
+
+npm install
+npm run
+
+```
+
+Then interact with the examples at:
+
+```
+localhost:8080
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-training",
+  "author": "Ryan Florence <rpflorence@gmail.com>",
+  "version": "0.0.1",
+  "description": "materials for react-training sessions at instructure",
+  "main": "",
+  "scripts": {
+    "start": "http-server"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "http-server": "^0.7.1"
+  }
+}


### PR DESCRIPTION
allows users to npm install, then npm start to serve examples locally
