### PR TITLE
Renaming React.renderComponent to React.render

### DIFF
--- a/lessons/05-wrapping-dom-libs.md
+++ b/lessons/05-wrapping-dom-libs.md
@@ -77,7 +77,7 @@ and then start rendering with React again. Some people call these
 DOM stuff, and then keep going on the other side.
 
 The big trick is rendering nothing and then calling
-`React.renderComponent` _inside_ a component.
+`React.render` _inside_ a component.
 
 ```js
 var Dialog = React.createClass({
@@ -94,7 +94,7 @@ var Dialog = React.createClass({
   
     // start a new React render tree with our node and the children
     // passed in from above, this is the other side of the portal.
-    React.renderComponent(<div>{this.props.children}</div>, node):
+    React.render(<div>{this.props.children}</div>, node):
   }
 });
 ```
@@ -144,7 +144,7 @@ var Dialog = React.createClass({
     props = props || this.props;
 
     // the code that used to be in `componentDidMount`
-    React.renderComponent(<div>{props.children}</div>, this.node):
+    React.render(<div>{props.children}</div>, this.node):
   }
 });
 ```
@@ -213,7 +213,7 @@ var Dialog = React.createClass({
 
   renderDialogContent: function(props) {
     // ...
-    React.renderComponent(<div>{props.children}</div>, this.node):
+    React.render(<div>{props.children}</div>, this.node):
 
     // after we've rendered the dialog, now we can call methods on it
     // via the props passed in like


### PR DESCRIPTION
https://facebook.github.io/react/blog/2014/10/28/react-v0.12.html
"To align with render methods in your component classes, we decided to keep the top-level functions short and sweet. React.renderComponent is now React.render."
